### PR TITLE
Add Raspios Trixie layer to the core repository

### DIFF
--- a/container/repositories/core/layers/raspios-trixie.arm64.toml
+++ b/container/repositories/core/layers/raspios-trixie.arm64.toml
@@ -1,0 +1,3 @@
+name = "Raspberry Pi OS (Trixie)"
+url = "https://downloads.raspberrypi.com/raspios_lite_arm64/images/raspios_lite_arm64-2025-12-04/2025-12-04-raspios-trixie-arm64-lite.img.xz"
+


### PR DESCRIPTION
To use the latests Raspios (Trixie) as a core layer